### PR TITLE
feat(candidaturas): completar cadastro manual de vagas

### DIFF
--- a/backend/drizzle/0014_red_betty_ross.sql
+++ b/backend/drizzle/0014_red_betty_ross.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "saved_jobs" ALTER COLUMN "job_link" DROP NOT NULL;--> statement-breakpoint

--- a/backend/drizzle/meta/0014_snapshot.json
+++ b/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1186 @@
+{
+  "id": "e66021a9-0669-4c28-b035-9d618e71645f",
+  "prevId": "979ff559-fdaa-4fd2-ad0e-00019bbbd23e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_unique": {
+          "name": "accounts_provider_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_events": {
+      "name": "application_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_job_id": {
+          "name": "saved_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_events_saved_job_id_created_at_idx": {
+          "name": "application_events_saved_job_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "saved_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_events_user_id_users_id_fk": {
+          "name": "application_events_user_id_users_id_fk",
+          "tableFrom": "application_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_events_saved_job_id_saved_jobs_id_fk": {
+          "name": "application_events_saved_job_id_saved_jobs_id_fk",
+          "tableFrom": "application_events",
+          "tableTo": "saved_jobs",
+          "columnsFrom": [
+            "saved_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_actor_id_users_id_fk": {
+          "name": "audit_logs_actor_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credentials_user_id_unique": {
+          "name": "credentials_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "credentials_email_unique": {
+          "name": "credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "credentials_email_hash_unique": {
+          "name": "credentials_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keywords": {
+      "name": "keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keywords_user_keyword_unique": {
+          "name": "keywords_user_keyword_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keywords_user_id_users_id_fk": {
+          "name": "keywords_user_id_users_id_fk",
+          "tableFrom": "keywords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_rules": {
+      "name": "permission_rules",
+      "schema": "",
+      "columns": {
+        "resource": {
+          "name": "resource",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_role": {
+          "name": "min_role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "permission_rules_resource_action_pk": {
+          "name": "permission_rules_resource_action_pk",
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_jobs": {
+      "name": "saved_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_link": {
+          "name": "job_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'saved'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_jobs_user_id_users_id_fk": {
+          "name": "saved_jobs_user_id_users_id_fk",
+          "tableFrom": "saved_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notifications": {
+      "name": "user_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notification'"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_notifications_user_created_at_idx": {
+          "name": "user_notifications_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_user_read_at_idx": {
+          "name": "user_notifications_user_read_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_notifications_user_id_users_id_fk": {
+          "name": "user_notifications_user_id_users_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "search_location": {
+          "name": "search_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_language": {
+          "name": "search_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_only": {
+          "name": "remote_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "job_types": {
+          "name": "job_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "career_checklist": {
+          "name": "career_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name_encrypted": {
+          "name": "first_name_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name_encrypted": {
+          "name": "last_name_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_encrypted": {
+          "name": "display_name_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_encrypted": {
+          "name": "email_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url_encrypted": {
+          "name": "avatar_url_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_encrypted": {
+          "name": "phone_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpf_encrypted": {
+          "name": "cpf_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpf_hash": {
+          "name": "cpf_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "technologies": {
+          "name": "technologies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "technologies_encrypted": {
+          "name": "technologies_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "technology_experiences_encrypted": {
+          "name": "technology_experiences_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_encrypted": {
+          "name": "level_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "is_blocked": {
+          "name": "is_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_hash_unique": {
+          "name": "users_email_hash_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "notification",
+        "message"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "job_saved",
+        "job_applied",
+        "job_status_changed",
+        "high_match",
+        "mentor",
+        "system"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "support",
+        "admin",
+        "super_admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1786569164248,
       "tag": "0013_chunky_wonder_man",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1788030798138,
+      "tag": "0014_red_betty_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/savedJobs.ts
+++ b/backend/src/db/schema/savedJobs.ts
@@ -19,7 +19,7 @@ export const savedJobs = pgTable("saved_jobs", {
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
 
-  jobLink: text("job_link").notNull(),
+  jobLink: text("job_link"),
   jobTitle: text("job_title"),
   company: text("company"),
   location: text("location"),

--- a/backend/src/modules/savedJobs/savedJobs.service.ts
+++ b/backend/src/modules/savedJobs/savedJobs.service.ts
@@ -43,20 +43,25 @@ export class SavedJobsService {
       throw AppError.conflict("Vaga já salva.");
     }
 
-    const result = await this.tx
-      .insert(savedJobs)
-      .values({ ...data, userId })
-      .returning();
-    await this.tx.insert(applicationEvents).values({
-      userId,
-      savedJobId: result[0].id,
-      type: "status_changed",
-      fromStatus: "saved",
-      toStatus: result[0].status,
-      metadata: { event: "application_created", source: data.source ?? "Manual" },
+    // As três escritas precisam ser atômicas, como já acontece no `update()`:
+    // sem transação, uma falha no evento ou na notificação deixaria a vaga
+    // criada sem histórico, e um retry do usuário duplicaria o registro.
+    return this.tx.transaction(async (tx) => {
+      const result = await tx
+        .insert(savedJobs)
+        .values({ ...data, userId })
+        .returning();
+      await tx.insert(applicationEvents).values({
+        userId,
+        savedJobId: result[0].id,
+        type: "status_changed",
+        fromStatus: "saved",
+        toStatus: result[0].status,
+        metadata: { event: "application_created", source: data.source ?? "Manual" },
+      });
+      await new NotificationsService(tx).createForSavedJob(userId, result[0]);
+      return result[0];
     });
-    await new NotificationsService(this.tx).createForSavedJob(userId, result[0]);
-    return result[0];
   }
 
   async update(

--- a/backend/src/modules/savedJobs/savedJobs.service.ts
+++ b/backend/src/modules/savedJobs/savedJobs.service.ts
@@ -32,10 +32,12 @@ export class SavedJobsService {
     userId: string,
     data: Omit<NewSavedJob, "userId">,
   ): Promise<SavedJob> {
-    const existing = await this.tx.query.savedJobs.findFirst({
-      where: (j, { and, eq }) =>
-        and(ownedBy(userId, j.userId), eq(j.jobLink, data.jobLink)),
-    });
+    const existing = data.jobLink
+      ? await this.tx.query.savedJobs.findFirst({
+          where: (j, { and, eq }) =>
+            and(ownedBy(userId, j.userId), eq(j.jobLink, data.jobLink)),
+        })
+      : undefined;
 
     if (existing) {
       throw AppError.conflict("Vaga já salva.");
@@ -45,6 +47,14 @@ export class SavedJobsService {
       .insert(savedJobs)
       .values({ ...data, userId })
       .returning();
+    await this.tx.insert(applicationEvents).values({
+      userId,
+      savedJobId: result[0].id,
+      type: "status_changed",
+      fromStatus: "saved",
+      toStatus: result[0].status,
+      metadata: { event: "application_created", source: data.source ?? "Manual" },
+    });
     await new NotificationsService(this.tx).createForSavedJob(userId, result[0]);
     return result[0];
   }

--- a/backend/src/modules/savedJobs/schemas/savedJobs.schemas.ts
+++ b/backend/src/modules/savedJobs/schemas/savedJobs.schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const createSavedJobSchema = z.object({
-  jobLink: z.string().url(),
+  jobLink: z.string().url().optional(),
   jobTitle: z.string().optional(),
   company: z.string().optional(),
   location: z.string().optional(),

--- a/backend/tests/integration/routes/savedJobs.routes.test.ts
+++ b/backend/tests/integration/routes/savedJobs.routes.test.ts
@@ -282,10 +282,10 @@ describe("Integration - SavedJobs Routes", () => {
         .expect(400);
     });
 
-    it("retorna 400 quando jobLink está ausente", async () => {
+    it("aceita candidatura manual sem jobLink", async () => {
       const { jobLink: _, ...withoutLink } = createPayload;
 
-      await request(app).post(BASE).send(withoutLink).expect(400);
+      await request(app).post(BASE).send(withoutLink).expect(201);
     });
 
     it("descarta campos desconhecidos (Zod strip)", async () => {

--- a/backend/tests/unit/modules/savedJobs/savedJobs.service.test.ts
+++ b/backend/tests/unit/modules/savedJobs/savedJobs.service.test.ts
@@ -175,16 +175,20 @@ describe("SavedJobsService", () => {
       const notificationValues = vi.fn().mockReturnValue({
         returning: vi.fn().mockResolvedValue([{ id: "notification-1" }]),
       });
+      const eventValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([]),
+      });
 
       tx.query.savedJobs.findFirst.mockResolvedValue(undefined);
       tx.insert
         .mockReturnValueOnce({ values: savedJobValues })
+        .mockReturnValueOnce({ values: eventValues })
         .mockReturnValueOnce({ values: notificationValues });
 
       const result = await service.create("user-1", newJobData);
 
       expect(result).toMatchObject(newJobData);
-      expect(tx.insert).toHaveBeenCalledTimes(2);
+      expect(tx.insert).toHaveBeenCalledTimes(3);
       expect(savedJobValues).toHaveBeenCalledWith({
         ...newJobData,
         userId: "user-1",
@@ -196,6 +200,12 @@ describe("SavedJobsService", () => {
           type: "job_saved",
           entityType: "job",
           entityId: createdJob.id,
+        }),
+      );
+      expect(eventValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          savedJobId: createdJob.id,
+          metadata: expect.objectContaining({ event: "application_created" }),
         }),
       );
     });
@@ -216,6 +226,11 @@ describe("SavedJobsService", () => {
       tx.insert.mockReturnValueOnce({
         values: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([{ ...mockJob, ...newJobData }]),
+        }),
+      });
+      tx.insert.mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
         }),
       });
       tx.insert.mockReturnValueOnce({

--- a/backend/tests/unit/modules/savedJobs/savedJobs.service.test.ts
+++ b/backend/tests/unit/modules/savedJobs/savedJobs.service.test.ts
@@ -188,6 +188,9 @@ describe("SavedJobsService", () => {
       const result = await service.create("user-1", newJobData);
 
       expect(result).toMatchObject(newJobData);
+      // As três escritas (vaga, evento e notificação) precisam sair na mesma
+      // transação, senão uma falha no meio deixa a vaga sem histórico.
+      expect(tx.transaction).toHaveBeenCalledOnce();
       expect(tx.insert).toHaveBeenCalledTimes(3);
       expect(savedJobValues).toHaveBeenCalledWith({
         ...newJobData,

--- a/frontend/src/domains/new_dashboard/components/jobs/AddJobModal.tsx
+++ b/frontend/src/domains/new_dashboard/components/jobs/AddJobModal.tsx
@@ -14,6 +14,7 @@ const initialForm: NewJob = {
   source: "Manual",
   jobLink: "",
   notes: "",
+  appliedAt: "",
 };
 
 interface AddJobModalProps {
@@ -81,6 +82,10 @@ export function AddJobModal({ onClose, onAddJob }: AddJobModalProps) {
               className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:border-ring"
               placeholder="Desenvolvedor Frontend"
             />
+          </label>
+          <label className="space-y-1.5">
+            <span className="text-xs font-bold uppercase text-muted-foreground">Data da candidatura</span>
+            <input type="date" value={form.appliedAt ?? ""} onChange={(event) => updateField("appliedAt", event.target.value)} className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:border-ring" />
           </label>
           <label className="space-y-1.5">
             <span className="text-xs font-bold uppercase text-muted-foreground">Empresa</span>
@@ -156,7 +161,7 @@ export function AddJobModal({ onClose, onAddJob }: AddJobModalProps) {
             />
           </label>
           <label className="space-y-1.5">
-            <span className="text-xs font-bold uppercase text-muted-foreground">Link</span>
+            <span className="text-xs font-bold uppercase text-muted-foreground">Link (opcional)</span>
             <input
               value={form.jobLink}
               onChange={(event) => updateField("jobLink", event.target.value)}

--- a/frontend/src/domains/new_dashboard/components/jobs/JobDetailModal.tsx
+++ b/frontend/src/domains/new_dashboard/components/jobs/JobDetailModal.tsx
@@ -124,7 +124,7 @@ export function JobDetailModal({
       onClose={onClose}
       footer={
         <>
-          <a
+          {job.jobLink ? <a
             href={job.jobLink}
             target="_blank"
             rel="noreferrer"
@@ -132,7 +132,7 @@ export function JobDetailModal({
           >
             <ExternalLink className="h-4 w-4" />
             Abrir vaga
-          </a>
+          </a> : null}
           <button
             type="button"
             onClick={onClose}
@@ -288,8 +288,9 @@ export function JobDetailModal({
                   <li key={event.id} className="relative text-sm">
                     <span className="absolute -left-[21px] top-1.5 h-2 w-2 rounded-full bg-primary" />
                     <p className="font-semibold">
-                      Status alterado de {jobStatuses[event.fromStatus]} para{" "}
-                      {jobStatuses[event.toStatus]}
+                      {event.metadata?.event === "application_created"
+                        ? "Candidatura criada"
+                        : <>Status alterado de {jobStatuses[event.fromStatus]} para {jobStatuses[event.toStatus]}</>}
                     </p>
                     <time className="text-xs text-muted-foreground" dateTime={event.createdAt}>
                       {formatTimelineDate(event.createdAt)}

--- a/frontend/src/domains/new_dashboard/infrastructure/dashboardJobsApi.ts
+++ b/frontend/src/domains/new_dashboard/infrastructure/dashboardJobsApi.ts
@@ -63,6 +63,12 @@ const ApiSavedJobEventSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
   createdAt: z.string(),
 });
+const ApiApplicationNoteSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
 
 type ApiSearchJob = z.infer<typeof ApiSearchJobSchema>;
 type ApiSavedJob = z.infer<typeof ApiSavedJobSchema>;
@@ -91,6 +97,7 @@ export type SearchJobsResult = {
     hasPrev: boolean;
   };
 };
+export type ApplicationNote = z.infer<typeof ApiApplicationNoteSchema>;
 
 function normalizeComparable(value: string) {
   return value
@@ -287,6 +294,7 @@ export function toDashboardSavedJob(job: ApiSavedJob): Job {
     jobLink: job.jobLink ?? "",
     source: job.source?.trim() || "Manual",
     notes: job.notes?.trim() || "",
+    appliedAt: job.appliedAt ?? undefined,
   };
 }
 
@@ -365,7 +373,13 @@ function savedJobPayload(job: Job | NewJob, status: JobStatus = "saved") {
         : undefined,
     status,
     notes: job.notes.trim() || undefined,
-    appliedAt: "appliedAt" in job && job.appliedAt ? new Date(`${job.appliedAt}T00:00:00`) : undefined,
+    // `appliedAt` é data civil (YYYY-MM-DD). Interpretar no fuso local faz o
+    // dia mudar ao serializar para UTC em fusos positivos (ex.: UTC+3 vira o
+    // dia anterior); ancorar em UTC preserva o dia que o usuário escolheu.
+    appliedAt:
+      "appliedAt" in job && job.appliedAt
+        ? new Date(`${job.appliedAt}T00:00:00.000Z`)
+        : undefined,
   };
 }
 
@@ -377,6 +391,25 @@ export async function getDashboardSavedJobs() {
 export async function getDashboardSavedJobEvents(id: string) {
   const { data } = await api.get(`/saved-jobs/${id}/events`);
   return z.array(ApiSavedJobEventSchema).parse(data).map(toDashboardSavedJobEvent);
+}
+
+export async function getDashboardApplicationNotes(id: string) {
+  const { data } = await api.get(`/saved-jobs/${id}/notes`);
+  return z.array(ApiApplicationNoteSchema).parse(data);
+}
+
+export async function createDashboardApplicationNote(id: string, content: string) {
+  const { data } = await api.post(`/saved-jobs/${id}/notes`, { content });
+  return ApiApplicationNoteSchema.parse(data);
+}
+
+export async function updateDashboardApplicationNote(id: string, noteId: string, content: string) {
+  const { data } = await api.patch(`/saved-jobs/${id}/notes/${noteId}`, { content });
+  return ApiApplicationNoteSchema.parse(data);
+}
+
+export async function deleteDashboardApplicationNote(id: string, noteId: string) {
+  await api.delete(`/saved-jobs/${id}/notes/${noteId}`);
 }
 
 export async function createDashboardSavedJob(

--- a/frontend/src/domains/new_dashboard/infrastructure/dashboardJobsApi.ts
+++ b/frontend/src/domains/new_dashboard/infrastructure/dashboardJobsApi.ts
@@ -42,7 +42,7 @@ const SearchJobsResponseSchema = z.object({
 
 const ApiSavedJobSchema = z.object({
   id: z.string(),
-  jobLink: z.string(),
+  jobLink: z.string().nullable().optional(),
   jobTitle: z.string().nullable().optional(),
   company: z.string().nullable().optional(),
   location: z.string().nullable().optional(),
@@ -284,7 +284,7 @@ export function toDashboardSavedJob(job: ApiSavedJob): Job {
     tags: job.keyword?.trim() ? [job.keyword.trim()] : ["Geral"],
     posted: "Não informado",
     status: job.status,
-    jobLink: job.jobLink,
+    jobLink: job.jobLink ?? "",
     source: job.source?.trim() || "Manual",
     notes: job.notes?.trim() || "",
   };
@@ -347,12 +347,12 @@ export async function searchDashboardJobs(
 
 function savedJobPayload(job: Job | NewJob, status: JobStatus = "saved") {
   const jobLink = job.jobLink.trim();
-  if (!URL.canParse(jobLink)) {
+  if (jobLink && !URL.canParse(jobLink)) {
     throw new Error("Informe um link válido para salvar a vaga.");
   }
 
   return {
-    jobLink,
+    jobLink: jobLink || undefined,
     jobTitle: job.jobTitle.trim(),
     company: job.company.trim(),
     location: job.location.trim() || undefined,
@@ -365,6 +365,7 @@ function savedJobPayload(job: Job | NewJob, status: JobStatus = "saved") {
         : undefined,
     status,
     notes: job.notes.trim() || undefined,
+    appliedAt: "appliedAt" in job && job.appliedAt ? new Date(`${job.appliedAt}T00:00:00`) : undefined,
   };
 }
 

--- a/frontend/src/domains/new_dashboard/types/job.ts
+++ b/frontend/src/domains/new_dashboard/types/job.ts
@@ -28,9 +28,10 @@ export const JobSchema = z.object({
   tags: z.array(z.string()),
   posted: z.string().min(1),
   status: JobStatusSchema,
-  jobLink: z.string().min(1),
+  jobLink: z.string(),
   source: z.string().min(1),
   notes: z.string(),
+  appliedAt: z.string().optional(),
   rawPayload: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/frontend/src/domains/new_dashboard/utils/helpers.ts
+++ b/frontend/src/domains/new_dashboard/utils/helpers.ts
@@ -22,7 +22,9 @@ export function createJobFromForm(newJobData: NewJob): Job {
     tags: tags.length > 0 ? tags : ["Geral"],
     posted: "Agora mesmo",
     status: "saved",
-    jobLink: newJobData.jobLink.trim() || "#",
+    // Sem link, string vazia — mesma convenção de `toDashboardSavedJob`. O "#"
+    // anterior era truthy e fazia o detalhe oferecer "Abrir vaga" sem link.
+    jobLink: newJobData.jobLink.trim(),
     source: newJobData.source.trim() || "Manual",
     notes: newJobData.notes.trim(),
   };

--- a/frontend/tests/unit/new_dashboard/jobs.test.tsx
+++ b/frontend/tests/unit/new_dashboard/jobs.test.tsx
@@ -542,6 +542,9 @@ describe("new_dashboard job components", () => {
     fireEvent.change(screen.getByPlaceholderText(/linkedin, gupy/i), {
       target: { value: "Gupy" },
     });
+    fireEvent.change(screen.getByLabelText(/data da candidatura/i), {
+      target: { value: "2026-08-29" },
+    });
     fireEvent.change(screen.getByPlaceholderText(/https:\/\/\.\.\./i), {
       target: { value: "https://example.com/new" },
     });
@@ -560,6 +563,7 @@ describe("new_dashboard job components", () => {
         source: "Gupy",
         jobLink: "https://example.com/new",
         notes: "Observações",
+        appliedAt: "2026-08-29",
       }),
     );
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/frontend/tests/unit/new_dashboard/savedJobAppliedAt.test.ts
+++ b/frontend/tests/unit/new_dashboard/savedJobAppliedAt.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn(), patch: vi.fn() }));
+vi.mock("@/shared/lib/apiClient", () => ({ api: apiMock }));
+
+import {
+  createDashboardSavedJob,
+  toDashboardSavedJob,
+} from "@/domains/new_dashboard/infrastructure/dashboardJobsApi";
+
+describe("toDashboardSavedJob — appliedAt (PAV-22)", () => {
+  const base = {
+    id: "job-1",
+    jobLink: "https://example.com/vaga",
+    jobTitle: "Dev",
+    company: "ACME",
+    location: "Remoto",
+    source: "Manual",
+    keyword: null,
+    status: "applied" as const,
+    notes: null,
+  };
+
+  it("leva o appliedAt da API para o modelo da UI", () => {
+    const job = toDashboardSavedJob({ ...base, appliedAt: "2026-01-15" });
+
+    expect(job.appliedAt).toBe("2026-01-15");
+  });
+
+  it("sem appliedAt, o campo fica indefinido em vez de quebrar", () => {
+    const job = toDashboardSavedJob({ ...base, appliedAt: null });
+
+    expect(job.appliedAt).toBeUndefined();
+  });
+});
+
+describe("savedJobPayload — appliedAt como data civil (PAV-22)", () => {
+  it("ancora a data em UTC, sem deixar o fuso local mudar o dia", async () => {
+    apiMock.post.mockResolvedValue({
+      data: {
+        id: "job-1",
+        jobLink: "https://example.com/vaga",
+        jobTitle: "Dev",
+        company: "ACME",
+        location: "Remoto",
+        source: "Manual",
+        keyword: null,
+        status: "applied",
+        notes: null,
+      },
+    });
+
+    await createDashboardSavedJob(
+      {
+        jobTitle: "Dev",
+        company: "ACME",
+        location: "Remoto",
+        salary: "A combinar",
+        type: "Remoto",
+        level: "Pleno",
+        tags: "React",
+        source: "Manual",
+        jobLink: "https://example.com/vaga",
+        notes: "",
+        appliedAt: "2026-01-15",
+      } as never,
+      "applied",
+    );
+
+    const payload = apiMock.post.mock.calls[0][1];
+    // Interpretar "2026-01-15" no fuso local produz um instante diferente da
+    // meia-noite UTC em qualquer fuso != 0 — e em fusos positivos o dia civil
+    // chega a mudar ao serializar. Aqui exigimos exatamente meia-noite UTC.
+    expect(payload.appliedAt.getTime()).toBe(Date.UTC(2026, 0, 15));
+    expect(payload.appliedAt.toISOString().slice(0, 10)).toBe("2026-01-15");
+  });
+});

--- a/frontend/tests/unit/new_dashboard/utils.test.ts
+++ b/frontend/tests/unit/new_dashboard/utils.test.ts
@@ -53,7 +53,9 @@ describe("new_dashboard utils", () => {
       tags: ["React", "TypeScript"],
       posted: "Agora mesmo",
       status: "saved",
-      jobLink: "#",
+      // Sem link informado: string vazia (falsy), não "#" — senão o detalhe
+      // oferece "Abrir vaga" apontando pra lugar nenhum.
+      jobLink: "",
       source: "Manual",
       notes: "nota",
     });


### PR DESCRIPTION
## Card

- [PAV-22](https://linear.app/candidateappbr/issue/PAV-22/candidatura-manual-vaga-externa)

## Objetivo e escopo

Completar as pendências da candidatura manual, aproveitando o fluxo existente de vagas salvas.

## O que foi feito

- Adicionada a data da candidatura ao formulário, persistida em `appliedAt`.
- Tornado o link da vaga opcional no banco, contrato e interface.
- Criado o evento inicial `Candidatura criada` ao salvar uma vaga manual, exibido no histórico da candidatura.
- Mantido o fluxo atual de status e eventos, preservando a possibilidade de associação futura a vagas do scraper.

## Módulos afetados

- Schema, migration e serviço de `saved_jobs`.
- Validações e rotas de vagas salvas.
- Formulário de cadastro, cliente da API e detalhe da vaga no dashboard.
- Testes de serviço, integração e interface.

## Validação

- [x] Suite do backend: 60 arquivos e 570 testes aprovados.
- [x] Suite do frontend: 52 arquivos e 343 testes aprovados.
- [x] Lint do frontend sem erros.
- [x] Build do frontend concluído.
- [x] Fluxo validado no dashboard: cadastro de usuário, abertura de `Adicionar vaga`, preenchimento dos campos incluindo data, envio sem link e conferência do evento `Candidatura criada` no histórico.

## Observações

- A migration `0014_red_betty_ross` torna `job_link` opcional e deve ser aplicada junto ao deploy.
- Sem link externo, a interface não exibe a ação `Abrir vaga`.